### PR TITLE
Feature: allow custom LaTeX preamble injection in exam configuration

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ Current development state:
 
 ### Added
 
+- **Custom LaTeX Preamble:** The `exam-assembler` and LaTeX formatter now support injecting raw LaTeX code directly into the document preamble, enabling question-specific packages (e.g., `\usepackage{menukeys}`) without modifying the core style file.
 - **OMR Registration Grid:** The LaTeX formatter and `provastyle.sty` now support generating a dynamic, machine-readable bubbling grid for student registration numbers (matrícula) on the answer sheet. It automatically emits `id_C_R` cell coordinates and page alignment markers to the `.zonas` file for automated grading.
 - **`examforge-mockgen` CLI tool:** A new application to generate random, synthetic question banks and exam configurations to stress-test constraint algorithms.
 - **Semantic Groups Implementation:** The `exam-assembler` now features a stateful constraint solver that safely rotates overlapping semantic groups across infinite variant streams without violating quotas.
@@ -34,6 +35,7 @@ Current development state:
 
 ### Spec (v3.1)
 
+- **LaTeX Preamble Configuration:** Added an optional `latex_preamble` string field to the `content` block. This allows authors to define custom macros or import packages directly from the YAML configuration.
 - **Registration Digits Configuration:** Added an optional `registration_digits` integer field to `assembly_options`. If provided and greater than `0`, it triggers the generation of the OMR registration grid on the answer sheet.
 - **Semantic Group Constraints:** Introduced `selection.semantic_groups` to the Exam Configuration schema. This allows setting multi-dimensional, regex-based maximum quotas for specific conceptual groups across exam variants.
 - **Random Seed Configuration:** Added an optional `seed` integer field to `assembly_options`. When provided, it explicitly initializes the PRNG to guarantee reproducible exam and variant selections.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -241,14 +241,22 @@ The assembler will rotate available questions within a semantic group across the
 
 Additional content to be inserted into the exam.
 
+* `latex_preamble` (String, Optional)  
+  A block of raw LaTeX code to be injected into the document preamble (between `\usepackage{provastyle}` and `\begin{document}`).  
+  Useful for importing specific packages (e.g., `\usepackage{menukeys}`) or defining custom LaTeX macros required by specific questions in the exam.  
+  Default: `""`
+
 * `instructions` (String)  
-  A (possibly multi-line) string of instructions printed on the title page.
+  A (possibly multi-line) string of instructions printed on the title page.  
   Default: `""`.
 
 Example:
 
 ```yaml
 content:
+  latex_preamble: |
+    \usepackage{menukeys}
+    \newcommand{\mycustommacro}[1]{\textbf{#1}}
   instructions: |
     Read the questions carefully.
     No electronic devices are allowed.

--- a/app/Assemble.hs
+++ b/app/Assemble.hs
@@ -184,6 +184,7 @@ assembleExams baseName config filteredQuestions
             , showTags           = show_tags (assembly_options config)
             , showSubject        = not (hide_subjects (assembly_options config))
             , registrationDigits = registration_digits (assembly_options config)
+            , latexPreamble      = latex_preamble (content config)
             }
 
       -- Initialize Pseudo-Random Generators

--- a/src/ExamForge/ExamConfig.hs
+++ b/src/ExamForge/ExamConfig.hs
@@ -92,16 +92,21 @@ instance FromJSON Selection where
 
 -- | Corresponds to the 'content' section.
 data Content = Content
-  { instructions :: String
+  { instructions   :: String
+  , latex_preamble :: String  -- Código a ser injetado no preâmbulo
   } deriving (Show, Generic)
 
 -- | Default values for Content.
 defaultContent :: Content
-defaultContent = Content { instructions = "" }
+defaultContent = Content
+  { instructions   = ""
+  , latex_preamble = ""       -- Default é vazio
+  }
 
 instance FromJSON Content where
   parseJSON = withObject "Content" $ \v -> Content
-    <$> v .:? "instructions" .!= instructions defaultContent
+    <$> v .:? "instructions"   .!= instructions defaultContent
+    <*> v .:? "latex_preamble" .!= latex_preamble defaultContent
 
 -- | Main configuration structure. Now handles optional sections.
 data Config = Config

--- a/src/ExamForge/Formatter/Latex.hs
+++ b/src/ExamForge/Formatter/Latex.hs
@@ -16,6 +16,7 @@ data FormatterConfig = FormatterConfig
   , showTags           :: Bool
   , showSubject        :: Bool
   , registrationDigits :: Maybe Int
+  , latexPreamble      :: String
   } deriving (Show)
 
 -- | The main function that generates the complete .tex file string.
@@ -28,6 +29,7 @@ format header config version examData =
     unlines
       [ "\\documentclass[a4paper,10pt,brazil]{article}"
       , "\\usepackage{provastyle}"
+      , latexPreamble config  -- Inject the user code here
       , "\\begin{document}"
       , formatHeader header version
       , "\\begin{multicols}{2}"


### PR DESCRIPTION
Added the `latex_preamble` field to the `content` block in the configuration schema. This allows users to inject arbitrary LaTeX code (like `\usepackage{...}` or custom macros) directly into the preamble of the generated `.tex` files, providing support for question-specific LaTeX dependencies without bloating the base style file.