### PR TITLE
fix: remove trailing comma in Haskell evaluator for static questions

### DIFF
--- a/src/ExamForge/Evaluator/Haskell.hs
+++ b/src/ExamForge/Evaluator/Haskell.hs
@@ -43,7 +43,7 @@ instance Evaluator HaskellEval where
 
       -- Generates an inline block for a specific row to leverage GHC type inference
       generateRow row idx =
-        let isLast = idx == length rows
+        let isLast = null rows || idx == length rows
             -- Indent bindings by 8 spaces to align under the 'let'
             bindings = map (\k -> "        " ++ k ++ " = " ++ M.findWithDefault "undefined" k row) paramNames
             letBlock = if null bindings 


### PR DESCRIPTION
When a question template lacked a `parameters` block, the Haskell evaluator incorrectly appended a trailing comma to the single JSON variant because `idx == length rows` evaluated to False (1 == 0).

Added a `null rows` check to `isLast` to ensure valid JSON is emitted for non-parameterized questions.