### PR TITLE
feature: improve YAML parsing error messages and context

### DIFF
--- a/app/ExamForge.hs
+++ b/app/ExamForge.hs
@@ -7,15 +7,18 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Control.Monad (forM)
+import Control.Exception (throwIO)
 import System.Exit (die)
 import System.FilePath (takeBaseName)
 import Text.Pretty.Simple (pShow)
 import Text.Pretty.Simple (pShow)
 import Data.Text.Lazy (unpack)
 import System.IO (hSetEncoding, stdout, stderr, utf8)
+import Data.Aeson (FromJSON)
+import Data.Yaml (decodeFileEither, ParseException(..), YamlException(..), YamlMark(..))
 
-import ExamForge.ExamConfig (ExamConfig(..), EvaluatorConfig(..), loadConfig)
-import ExamForge.QuestionBank (QuestionTemplate(..), Answer(..), Delimiters(..), loadQuestionBank)
+import ExamForge.ExamConfig (ExamConfig(..), EvaluatorConfig(..))
+import ExamForge.QuestionBank (QuestionTemplate(..), Answer(..), Delimiters(..))
 import ExamForge.Template (parseTemplate, AnswerAST(..))
 import ExamForge.Evaluator.Class (generateScript)
 import ExamForge.Evaluator.Python (PythonEval(..))
@@ -109,17 +112,16 @@ processTemplate evaluators defaultLang qt = do
 runBuild :: BuildOpts -> IO ()
 runBuild opts = do
   putStrLn $ "Loading config: " ++ buildConfigFile opts
-  configRes <- loadConfig (buildConfigFile opts)
-  cfg <- case configRes of
-    Left err -> die $ "Config error: " ++ show err
-    Right c  -> return c
+  cfg <- loadYamlOrDie "exam config" (buildConfigFile opts)
 
   let activeEvaluators = Map.union (evaluators cfg) defaultEvaluators
   let defLang = fromMaybe "python" (default_language cfg)
 
   putStrLn "Loading question banks..."
   -- Load all templates from all files (you might need to expand globs here if you use them)
-  allTemplates <- concat <$> mapM loadQuestionBank (question_banks cfg)
+  -- Map the helper over all configured banks and flatten the result
+  nestedTemplates <- mapM (loadYamlOrDie "Question bank") (question_banks cfg)
+  let allTemplates = concat nestedTemplates  
 
   putStrLn $ "Evaluating " ++ show (length allTemplates) ++ " templates..."
   evalResults <- mapM (processTemplate activeEvaluators defLang) allTemplates
@@ -150,7 +152,7 @@ runBuild opts = do
 runCheck :: CheckOpts -> IO ()
 runCheck opts = do
   putStrLn $ "Checking bank: " ++ checkBankFile opts
-  templates <- loadQuestionBank (checkBankFile opts)
+  templates <- loadYamlOrDie "question bank" (checkBankFile opts)
   
   -- Filter by ID if requested
   let targetTemplates = case checkQuestionId opts of
@@ -178,6 +180,22 @@ runCheck opts = do
                 Left err -> putStrLn $ "[ERROR]\n" ++ err
                 Right q  -> putStrLn $ "[SUCCESS]\n" ++ unpack (pShow q)
             ) evalResults
+
+-- | Load a YAML file and handle parse errors with the file name
+loadYamlOrDie :: FromJSON a => String -> FilePath -> IO a
+loadYamlOrDie description filepath = do
+  res <- decodeFileEither filepath
+  case res of
+    Right result -> return result
+    Left err -> case err of
+      InvalidYaml (Just (YamlParseException {yamlProblemMark=mark, yamlProblem=problem, yamlContext=context})) ->
+        die $ "YAML parse exception at " ++
+                   filepath ++ 
+                   ":" ++ show (yamlLine mark + 1) ++
+                   ":" ++ show (yamlColumn mark + 1) ++ 
+                   "\n" ++ context ++ ":" ++
+                   "\n" ++ problem
+      _ -> throwIO err
 
 main :: IO ()
 main = do

--- a/src/ExamForge/ExamConfig.hs
+++ b/src/ExamForge/ExamConfig.hs
@@ -1,6 +1,5 @@
 -- File: src/ExamForge/ExamConfig.hs
 
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module ExamForge.ExamConfig
@@ -11,11 +10,9 @@ module ExamForge.ExamConfig
   , Selection(..)
   , EvaluatorConfig(..)
   , Content(..)
-  , loadConfig
   ) where
 
-import Data.Yaml
-import GHC.Generics
+import Data.Aeson
 import Control.Monad (when)
 import qualified Data.Map as Map
 
@@ -26,9 +23,15 @@ data Header = Header
   , professor :: String
   , semester :: String
   , title :: String
-  } deriving (Show, Generic)
+  } deriving (Show)
 
-instance FromJSON Header
+instance FromJSON Header where
+  parseJSON = withObject "Header" $ \v -> Header
+    <$> v .: "institution"
+    <*> v .: "course"
+    <*> v .: "professor"
+    <*> v .: "semester"
+    <*> v .: "title"
 
 -- | Corresponds to the 'assembly_options' section.
 data AssemblyOptions = AssemblyOptions
@@ -39,7 +42,7 @@ data AssemblyOptions = AssemblyOptions
   , shuffle_questions   :: Bool
   , seed                :: Maybe Int -- Optional random seed
   , registration_digits :: Maybe Int -- Optional field for OMR grid
-  } deriving (Show, Generic)
+  } deriving (Show)
 
 -- | Default values for AssemblyOptions.
 defaultAssemblyOptions :: AssemblyOptions
@@ -67,7 +70,7 @@ instance FromJSON AssemblyOptions where
 data SemanticGroupRule = SemanticGroupRule
   { tag_pattern :: String
   , maximum_qs :: Int
-  } deriving (Show, Generic)
+  } deriving (Show)
 
 instance FromJSON SemanticGroupRule where
   parseJSON = withObject "SemanticGroupRule" $ \v -> do
@@ -81,7 +84,7 @@ data Selection = Selection
   { include_tags :: [String]
   , exclude_tags :: [String]
   , semantic_groups :: [SemanticGroupRule]
-  } deriving (Show, Generic)
+  } deriving (Show)
 
 defaultSelection :: Selection
 defaultSelection = Selection [] [] []
@@ -96,7 +99,7 @@ instance FromJSON Selection where
 data Content = Content
   { instructions   :: String
   , latex_preamble :: String  -- Código a ser injetado no preâmbulo
-  } deriving (Show, Generic)
+  } deriving (Show)
 
 -- | Default values for Content.
 defaultContent :: Content
@@ -143,7 +146,3 @@ instance FromJSON ExamConfig where
     <*> v .:? "assembly_options" .!= defaultAssemblyOptions
     <*> v .:? "selection"        .!= defaultSelection
     <*> v .:? "content"          .!= defaultContent
-    
--- | Loads and parses an exam configuration file.
-loadConfig :: FilePath -> IO (Either ParseException ExamConfig)
-loadConfig = decodeFileEither

--- a/src/ExamForge/QuestionBank.hs
+++ b/src/ExamForge/QuestionBank.hs
@@ -1,3 +1,5 @@
+-- File: src/ExamForge/QuestionBank.hs
+
 {-# LANGUAGE OverloadedStrings #-}
 
 module ExamForge.QuestionBank 
@@ -6,11 +8,9 @@ module ExamForge.QuestionBank
   , Delimiters(..)
   , ParameterBlock(..)
   , Answer(..)
-  , loadQuestionBank
   ) where
 
 import Data.Aeson
-import Data.Yaml (decodeFileThrow)
 import Data.Map (Map)
 import qualified Data.Map as Map
 
@@ -89,10 +89,3 @@ instance FromJSON QuestionTemplate where
     <*> v .:  "question"
     <*> v .:  "answers"
     <*> v .:? "delimiters"
-
--- | Replaces your old ExamForge.Parser logic
-loadQuestionBank :: FilePath -> IO [QuestionTemplate]
-loadQuestionBank filepath = do
-  -- decodeFileThrow automatically handles YAML parsing and throws helpful 
-  -- exceptions if the file is missing or the schema is wrong.
-  decodeFileThrow filepath


### PR DESCRIPTION
This commit refactors YAML loading to handle errors at the application boundary, dramatically improving the developer experience (DX) when debugging configuration or template files.

Key changes:
- Replaced the library-specific `loadQuestionBank` and `loadConfig` functions with a generalized `loadYamlOrDie` helper in the CLI router. This function safely decodes any YAML file and intercepts `InvalidYaml` exceptions, formatting user-friendly error messages that explicitly state the offending file name, line number, and column number.
- Replaced the generic `FromJSON` instance for `Header` in `ExamConfig` with an explicit `withObject` implementation to ensure clean, predictable schema validation errors if fields are missing or mistyped.