### PR TITLE
feat: add --show-json flag to check command for debugging IR

### DIFF
--- a/ExamForge.cabal
+++ b/ExamForge.cabal
@@ -70,18 +70,19 @@ executable examforge
   main-is:          ExamForge.hs
 
   build-depends:
-    base >=4.12 && <5,
-    ExamForge,
-    Glob,
-    yaml,
-    directory,
-    filepath,
-    aeson,
-    pretty-show,
-    pretty-simple,
-    optparse-applicative,
-    containers,
-    text
+    , base >=4.12 && <5
+    , ExamForge
+    , Glob
+    , yaml
+    , directory
+    , filepath
+    , aeson
+    , pretty-show
+    , pretty-simple
+    , optparse-applicative
+    , containers
+    , text
+    , bytestring
 
   hs-source-dirs:   app
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ content:
 
 ---
 
-
 ## Command-Line Usage
 
 The `examforge` CLI provides three main subcommands: `check`, `build`, and `mock`.
@@ -264,8 +263,11 @@ cabal run examforge -- check questions/my-bank.yml
 # Evaluate a specific question by ID
 cabal run examforge -- check questions/my-bank.yml --id py-math-01
 
-# Debugging: Dump the generated source code (Python, C, etc.) to the terminal without running it
+# Debugging: Dump the generated source code (Python, C, Haskell, etc.) to the terminal without running it
 cabal run examforge -- check questions/my-bank.yml -i py-math-01 --show-script
+
+# Debugging: Output the evaluated JSON Intermediate Representation (IR) bridging the script and Haskell AST
+cabal run examforge -- check questions/my-bank.yml -i py-math-01 --show-json
 ```
 
 ### 2. Assembling Exams (`build`)

--- a/app/ExamForge.hs
+++ b/app/ExamForge.hs
@@ -14,8 +14,9 @@ import Text.Pretty.Simple (pShow)
 import Text.Pretty.Simple (pShow)
 import Data.Text.Lazy (unpack)
 import System.IO (hSetEncoding, stdout, stderr, utf8)
-import Data.Aeson (FromJSON)
+import Data.Aeson (FromJSON, ToJSON, encode)
 import Data.Yaml (decodeFileEither, ParseException(..), YamlException(..), YamlMark(..))
+import qualified Data.ByteString.Lazy.Char8 as BSL
 
 import ExamForge.ExamConfig (ExamConfig(..), EvaluatorConfig(..))
 import ExamForge.QuestionBank (QuestionTemplate(..), Answer(..), Delimiters(..))
@@ -56,6 +57,7 @@ data CheckOpts = CheckOpts
   , checkConfigFile :: Maybe FilePath
   , checkQuestionId :: Maybe String
   , checkShowScript :: Bool
+  , checkShowJson   :: Bool
   }
 
 -- | 3. CLI Parsers
@@ -67,7 +69,8 @@ checkParser = Check <$> (CheckOpts
   <$> strArgument (metavar "BANK_FILE" <> help "Path to the question bank YAML")
   <*> optional (strOption (long "config" <> short 'c' <> metavar "CONFIG_FILE" <> help "Optional exam config override"))
   <*> optional (strOption (long "id" <> short 'i' <> metavar "QUESTION_ID" <> help "Only check a specific question ID"))
-  <*> switch (long "show-script" <> short 's' <> help "Output the generated script instead of evaluating it"))
+  <*> switch (long "show-script" <> short 's' <> help "Output the generated script instead of evaluating it")
+  <*> switch (long "show-json" <> short 'j' <> help "Output the evaluated JSON IR"))
 
 commandParser :: Parser Command
 commandParser = subparser
@@ -175,10 +178,14 @@ runCheck opts = do
     else do
       putStrLn $ "Found " ++ show (length targetTemplates) ++ " matching templates. Evaluating...\n"
       evalResults <- mapM (processTemplate defaultEvaluators "python") targetTemplates
-      
+
       mapM_ (\res -> case res of
                 Left err -> putStrLn $ "[ERROR]\n" ++ err
-                Right q  -> putStrLn $ "[SUCCESS]\n" ++ unpack (pShow q)
+                Right q  -> do
+                    putStrLn "[SUCCESS]"
+                    if checkShowJson opts
+                      then BSL.putStrLn (encode q)
+                      else putStrLn $ unpack (pShow q)
             ) evalResults
 
 -- | Load a YAML file and handle parse errors with the file name

--- a/src/ExamForge/Exam.hs
+++ b/src/ExamForge/Exam.hs
@@ -1,4 +1,12 @@
+-- File: src/ExamForge/Exam.hs
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
 module ExamForge.Exam where
+
+import Data.Aeson (ToJSON)
+import GHC.Generics (Generic)
 
 import ExamForge.QuestionBank (SelectionType)
 
@@ -17,4 +25,4 @@ data Question = Question
   , qTags          :: [String]
   , qSelectionType :: SelectionType
   , qVariants      :: [Variant]
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, ToJSON)

--- a/src/ExamForge/QuestionBank.hs
+++ b/src/ExamForge/QuestionBank.hs
@@ -1,6 +1,8 @@
 -- File: src/ExamForge/QuestionBank.hs
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 module ExamForge.QuestionBank 
   ( QuestionTemplate(..)
@@ -13,10 +15,11 @@ module ExamForge.QuestionBank
 import Data.Aeson
 import Data.Map (Map)
 import qualified Data.Map as Map
+import GHC.Generics (Generic)
 
 -- | Defines how correctness is evaluated.
 data SelectionType = SelectAny | SelectAll
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic, ToJSON)
 
 instance FromJSON SelectionType where
   parseJSON = withText "SelectionType" $ \t ->
@@ -29,7 +32,7 @@ instance FromJSON SelectionType where
 data Delimiters = Delimiters
   { startDelim :: String
   , endDelim   :: String
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, ToJSON)
 
 instance FromJSON Delimiters where
   parseJSON = withObject "Delimiters" $ \v -> Delimiters
@@ -40,7 +43,7 @@ instance FromJSON Delimiters where
 data ParameterBlock = ParameterBlock
   { paramTypes :: Map String String
   , paramRows  :: [Map String String]
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, ToJSON)
 
 instance FromJSON ParameterBlock where
   parseJSON = withObject "ParameterBlock" $ \v -> ParameterBlock
@@ -51,7 +54,7 @@ instance FromJSON ParameterBlock where
 data Answer
   = CorrectAnswer String
   | IncorrectAnswer String
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic, ToJSON)
 
 instance FromJSON Answer where
   parseJSON = withObject "Answer" $ \v -> do
@@ -73,7 +76,7 @@ data QuestionTemplate = QuestionTemplate
   , qtQuestion    :: String
   , qtAnswers     :: [Answer]
   , qtDelimiters  :: Maybe Delimiters
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Generic, ToJSON)
 
 instance FromJSON QuestionTemplate where
   parseJSON = withObject "QuestionTemplate" $ \v -> QuestionTemplate


### PR DESCRIPTION
This commit adds a new `-j` / `--show-json` flag to the `examforge check` subcommand. This allows instructors and developers to easily inspect the final JSON Intermediate Representation (IR) generated by the evaluators, bridging the gap between raw scripts and the Haskell AST.

Key changes:
- Added `checkShowJson` to `CheckOpts` and wired it to the CLI parser.
- Updated `runCheck` to output serialized JSON when the flag is present, falling back to the `pretty-simple` AST output otherwise.
- Added `DeriveGeneric` and `DeriveAnyClass` pragmas to `QuestionBank.hs` and `Exam.h`.
- Derived `Generic` and `ToJSON` instances for `QuestionTemplate` and all its nested data structures (`SelectionType`, `ParameterBlock`, etc.) to support the JSON serialization.